### PR TITLE
fix(trainings): "The Dark Side of APIs" markup

### DIFF
--- a/_data/trainings.yml
+++ b/_data/trainings.yml
@@ -34,31 +34,37 @@
   URL: https://www.eventbrite.com/e/owasp-global-appsec-lisbon-2024-tickets-750689411237?aff=oddtdtcreator
   SectionId: sku_TDSA
   Description: >-
-      Following a hands-on approach, attendees will be guided into exploiting the ten most common API security risks according to the OWASP API Security Top 10. The security issues will be discussed in-depth, also covering the mitigation. API protocol-specific security issues will be addressed and discussed to cover the most common API protocols. Training sessions are delivered by a security practitioner and OWASP project leader.<br>
-      <br>
-      Target Audience - API developers, DevSecOps, Pentesters, and systems integrators<br>
-      <br>
-      Training Program<br>
-      Part 1<br>
-      <br>
-      Introduction to the Open Web Application Security Project (OWASP), the OWASP API Security Project, and the OWASP API Top 10<br>
-      The HTTP protocol and how APIs work on top of it<br>
-      <br>
-      Part 2<br>
-      <br>
-      For each of the ten most common API security risks - according to the OWASP API Top 10<br>
-      Exploit the vulnerability<br>
-      Discuss the security issue, impact, and how to mitigate the risk GraphQL-specific security risks<br>
-      <br>
-      What You’ll Learn<br>
-      <br>
-      Relevant OWASP projects and how to use them to write secure code<br>
-      HTTP protocol fundamentals and how APIs work on top of it<br>
-      In-depth knowledge of the ten most common API security risks<br>
-      API protocol-specific risks e.g. GraphQL<br>
-      How threat agents exploit APIs vulnerabilities - tools and techniques<br>
-      How to avoid the most common API security issues<br>
-      <br>
+    <p>Following a hands-on approach, attendees will be guided into exploiting the ten most common API security risks according to the OWASP API Security Top 10. The security issues will be discussed in-depth, also covering the mitigation. API protocol-specific security issues will be addressed and discussed to cover the most common API protocols. Training sessions are delivered by a security practitioner and OWASP project leader.</p>
+    <h4>Target Audience</h4>
+    <p>API developers, DevSecOps, Pentesters, and systems integrators</p>
+    <h4>Training Program</h4>
+    <h5>Part 1</h5>
+    <ul>
+      <li>Introduction to the
+        <ul>
+          <li>Open Web Application Security Project (OWASP)</li>
+          <li>OWASP API Security Project</li>
+          <li>OWASP API Top 10</li>
+        </ul>
+      </li>
+      <li>The HTTP protocol and how APIs work on top of it</li>
+    </ul>
+    <h5>Part 2</h5>
+    <p>For each of the ten most common API security risks - according to the OWASP API Top 10:</p>
+    <ul>
+      <li>Exploit the vulnerability</li>
+      <li>Discuss the security issue, impact, and how to mitigate the risk</li>
+      <li>GraphQL-specific security risks</li>
+    </ul>
+    <h4>What You’ll Learn</h4>
+    <ul>
+      <li>Relevant OWASP projects and how to use them to write secure code</li>
+      <li>HTTP protocol fundamentals and how APIs work on top of it</li>
+      <li>In-depth knowledge of the ten most common API security risks</li>
+      <li>API protocol-specific risks e.g. GraphQL</li>
+      <li>How threat agents exploit APIs vulnerabilities - tools and techniques</li>
+      <li>How to avoid the most common API security issues</li>
+    </ul>
 - Type: Training
   Trainers: 
     - Name: Dr. Michael Loadenthal


### PR DESCRIPTION
Improve training description markup for visual and SEO purposes.

See the before vs after in the picture below:

![Screenshot from 2024-04-02 13-54-27](https://github.com/OWASP/www-event-2024-Global-AppSec-Lisbon/assets/2962581/7e7ded7c-b5cb-4dd9-ad75-db1c5d34404a)
